### PR TITLE
fix: address bug in finding branch to grow tree

### DIFF
--- a/GameSetup.cpp
+++ b/GameSetup.cpp
@@ -90,6 +90,7 @@ void GameSetup::transferInputFileDataToGame(AnimalNode*& newNode, AnimalNode*& r
             // algorithm for finding next point in binary tree to expand
             currentNode = rootNode;
             int counter = 0;
+            int loopCheck = 0;
             while (currentNode->yesAns) {
                 if (rootNodeYesAnsPathwayComplete && !onRootNodeNoPathway) {
                     currentNode = rootNode->noAns;
@@ -126,11 +127,17 @@ void GameSetup::transferInputFileDataToGame(AnimalNode*& newNode, AnimalNode*& r
                     currentNode = lastNodeWithBothPtrs->noAns;
                     if (currentNode->question != "") {
                         counter = 0;
-                        continue;
+                        //continue;
                     }
                     else if (currentNode->animal != "") {
                         counter++;
                         currentNode = lastNodeWithBothPtrs;
+                        //continue;
+                    }
+
+                    loopCheck++;
+                    if (loopCheck == 10) {
+                        counter = 2;
                         continue;
                     }
                 }


### PR DESCRIPTION
Temporarily (or maybe permanently) fixed this bug by breaking out of an endless loop after a certain amount of iterations and immediately going to the last node with only one pointer to fill out the rest of the tree